### PR TITLE
Bugfix - pass no tickers to stockprice

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
         "requests==2.28.2",
         "urllib3==1.26.14; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
     ],
-    version="2.1.1",
+    version="2.1.2",
     entry_points={"console_scripts": ["stockprice = stockprice.main:main"]},
 )

--- a/stockprice/main.py
+++ b/stockprice/main.py
@@ -4,7 +4,7 @@ from stockprice.calculate_price_movement import calculate_price_movement
 
 
 def main(args: list = sys.argv) -> None:
-    if len(args) == 1 and args[0] == "stockprice":
+    if len(args) == 1:
         print("Please provide at least one stock ticker.")
         print("Example: stockprice tsla,aapl")
         return


### PR DESCRIPTION
In reality first argument is something like /Users/thomas.mcinally/.pyenv/versions/3.10.4/bin/stockprice